### PR TITLE
Give user control over the number of rows/columns in the ERP dialog

### DIFF
--- a/ecogvis/functions/event_related_potential.py
+++ b/ecogvis/functions/event_related_potential.py
@@ -255,7 +255,7 @@ class ERPDialog(QMainWindow):
         # Update grid parameters
         try:
             self.nCols = int(self.qline_ncols.text())
-        except x:
+        except:
             self.nCols = self.guess_ncols()
             self.qline_ncols.setText(str(self.nCols))
         self.nRows = int(np.ceil(self.nElecs / self.nCols))


### PR DESCRIPTION
Previously, the code assumed that every grid had 16 electrodes/row. Now we need to handle 8x8 grids