### PR TITLE
Update setup.py to install correct pynwb version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'h5py',
         'pyqtgraph',
         'pandas',
-        'pynwb>=1.1.2',
+        'pynwb==1.3.2',
         'PyYAML',
         'ndx-ecog',
         'ndx-spectrum',


### PR DESCRIPTION
Currently, using pip will install the incorrect version of pynwb causing ecogVIS to crash when loading an NWB file.

Resolves Issue #118