### PR TITLE
Fix the version of process_nwb==0.1.0 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'ndx-bipolar-scheme',
         'tqdm',
         'pyopengl',
-        'process_nwb',
+        'process_nwb==0.1.0',
         'PyQtWebEngine',
         'ndx-icephys-meta',
         'ndx-hierarchical-behavioral-data'],


### PR DESCRIPTION
`process_nwb` has new changes that aren't backwards compatible -- it hasn't been updated on pypi/pip yet, but presumably it will eventually. We should fix the version number in setup.py so that developers don't accidentally get the wrong version when running `pip install -e .`