### PR TITLE
plotting code incorrectly assumed that self.selectedChannels was 1-in…

### DIFF
--- a/ecogvis/functions/subFunctions.py
+++ b/ecogvis/functions/subFunctions.py
@@ -261,7 +261,7 @@ class TimeSeriesPlotter:
 
         # constrains the plotData to the chosen interval (and transpose matix)
         # plotData dims=[self.nChToShow, plotInterval]
-        data = self.plotData[startSamp:endSamp, self.selectedChannels - 1].T
+        data = self.plotData[startSamp:endSamp, self.selectedChannels].T
         data = data[:, bins_to_plot - startSamp - 1]
         means = np.reshape(np.mean(data, 1), (-1, 1))  # to align each trace around its reference trace
         plotData = data + scaleV - means  # data + offset


### PR DESCRIPTION
…dexed and would subtract 1 to 0-index them. this caused e15 to be the last channel in the dataset. fixed by removing the incorrect

because the plotted channel numbers would've been incorrect, this could affect bad channel selection by visual inspection

@bendichter 