### PR TITLE
Add installation clarity and fixes for use on macOS 11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,50 @@ A collaboration with the [Chang Lab](http://changlab.ucsf.edu/).
 ![](media/screenshot_1.png)
 
 ## Installation
-```
+
+### From PyPI
+```bash
 $ pip install ecogVIS
 ```
 
-After activating the correct environment, **ecogVIS** can be started from the terminal:
+### From source
+First download the **ecogVIS** source code from this repo.
+```bash
+$ git clone https://github.com/catalystneuro/ecogVIS.git
+$ cd ecogVIS
 ```
+
+If you're installing into an active environment:
+```bash
+$ pip install -e . -r requirements.txt
+```
+
+You can also create a fresh environment with **ecogVIS** installed:
+```bash
+$ conda env create -f make_env.yml
+```
+
+### Troubleshooting
+* If you're using macOS 11+ (e.g. Big Sur or Monterey), you may experience 
+errors related to OpenGL. Using Python 3.8 should solve these, and you can 
+  use the file `make_env_py38.yml` to create the correct 
+  environment.
+* If you're using macOS 11+ (e.g. Big Sur or Monterey), you may also 
+  experience errors with PyQt freezing and not opening the GUI window. Try 
+  setting the following environment variable (which can be added to your 
+  `~/.bashrc` or `~/.bash_profile`):
+  ```bash
+  $ export QT_MAC_WANTS_LAYER=1
+  ```
+
+## Use
+After activating the correct environment, **ecogVIS** can be started from the terminal:
+```bash
 $ ecogvis
 ```
 
 You can also directly pass a file to be opened:
-```
+```bash
 $ ecogvis --source 'filename.nwb'
 ```
 

--- a/make_env.yml
+++ b/make_env.yml
@@ -22,4 +22,5 @@ dependencies:
   - PyQt5
   - ndx-ecog
   - ndx-spectrum
+  - -r requirements.txt
   - -e .

--- a/make_env_py38.yml
+++ b/make_env_py38.yml
@@ -1,0 +1,26 @@
+name: ecog_vis
+channels:
+- defaults
+- anaconda
+- conda-forge
+dependencies:
+- python=3.8
+- ipython
+- pip
+- numpy
+- scipy
+- pandas
+- jupyter
+- matplotlib
+- cycler
+- h5py
+- pyqtgraph
+- pynwb>=1.1.2
+- pyopengl
+- hdmf
+- pip:
+  - PyQt5
+  - ndx-ecog
+  - ndx-spectrum
+  - -r requirements.txt
+  - -e .


### PR DESCRIPTION
@bendichter 

I recently updated my Mac to macOS 12 Monterey and thus discovered several installation fixes that were needed as well as things that could be clearer in installing `ecogVIS`.

- macOS 11+ seems to completely reorganize (or abandon?) a lot of libraries, like OpenGL. Some work-around was created in Python, starting with v3.8. I did try the latest Python version (v3.10) but then there were changes to `collections` that were not compatible with `ndx-ecog` so I stuck with v3.8 which seems to work. I created a separate environment file in case anyone still wants v3.7.
- Another oddity of macOS 11+ is that after running `ecogvis` at the command line, the window would never visualize and just hang until I force quit. It appears changing one environmental variable fixes that (now added to the README).
- If you install from the `.yml` file, the correct versions of packages (detailed in `requirements.txt`) don't get installed, so I added a line to both `.yml`'s.

Happy to change any of these suggestions if needed